### PR TITLE
Expect the proper cloud-tenant subclass name

### DIFF
--- a/app/models/manageiq/providers/ibm_cic/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_cic/cloud_manager/template.rb
@@ -1,4 +1,9 @@
 ManageIQ::Providers::Openstack::CloudManager::Template.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmCic::CloudManager::Template < ManageIQ::Providers::Openstack::CloudManager::Template
+  has_and_belongs_to_many :cloud_tenants,
+                          :foreign_key             => "vm_id",
+                          :join_table              => "cloud_tenants_vms",
+                          :association_foreign_key => "cloud_tenant_id",
+                          :class_name              => "ManageIQ::Providers::IbmCic::CloudManager::CloudTenant"
 end

--- a/spec/models/manageiq/providers/ibm_cic/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cic/cloud_manager/refresher_spec.rb
@@ -91,7 +91,7 @@ describe ManageIQ::Providers::IbmCic::CloudManager::Refresher do
       :description => "IBM Default Tenant",
       :enabled     => true,
       :ems_ref     => "a0311bc440e64cbe90c1b947e171335a",
-      :type        => "ManageIQ::Providers::Openstack::CloudManager::CloudTenant" # TODO: Fix openstack parser
+      :type        => "ManageIQ::Providers::IbmCic::CloudManager::CloudTenant"
     )
   end
 
@@ -155,9 +155,9 @@ describe ManageIQ::Providers::IbmCic::CloudManager::Refresher do
       :power_state     => "never",
       :type            => "ManageIQ::Providers::IbmCic::CloudManager::Template",
       :ems_ref         => "d3f1f3db-9c81-46cc-b5ea-dda649e2ab9d",
-      :cloud_tenant    => ems.cloud_tenants.find_by(:ems_ref => "a0311bc440e64cbe90c1b947e171335a"),
       :raw_power_state => "never"
     )
+    expect(image.cloud_tenants).to include(ems.cloud_tenants.find_by(:ems_ref => "a0311bc440e64cbe90c1b947e171335a"))
   end
 
   def assert_specific_vm


### PR DESCRIPTION
Openstack parser has been fixed to not hard-code this as of https://github.com/ManageIQ/manageiq-providers-openstack/pull/758

Same fix as https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/34