### PR TITLE
Fix missing cinder_manager caused by association :class_name

### DIFF
--- a/app/models/manageiq/providers/ibm_cic/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cic/cloud_manager.rb
@@ -31,6 +31,13 @@ class ManageIQ::Providers::IbmCic::CloudManager < ManageIQ::Providers::Openstack
     @description ||= "IBM Cloud Infrastructure Center".freeze
   end
 
+  has_one :cinder_manager,
+          :foreign_key => :parent_ems_id,
+          :class_name  => "ManageIQ::Providers::IbmCic::StorageManager::CinderManager",
+          :dependent   => :destroy,
+          :inverse_of  => :parent_manager,
+          :autosave    => true
+
   def image_name
     "ibm_cic"
   end


### PR DESCRIPTION
The `:class_name` on the `:cinder_manager` association defined by the parent `Openstack::CloudManager` class was causing the IbmCic cinder manager to not be found.

This meant that even though a CinderManager record was created, `manager.cinder_manager` returned `nil`

https://github.com/ManageIQ/manageiq-providers-openstack/blob/master/app/models/manageiq/providers/openstack/cinder_manager_mixin.rb#L9