### PR TITLE
Get cpu_speed from cic to set into hardware. 

### DIFF
--- a/app/models/manageiq/providers/ibm_cic/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cic/inventory/parser/cloud_manager.rb
@@ -1,5 +1,4 @@
 class ManageIQ::Providers::IbmCic::Inventory::Parser::CloudManager < ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager
- 
   def parse_vm(vm, hosts)
     super
     server = persister.vms.find_or_build(vm.id.to_s)

--- a/app/models/manageiq/providers/ibm_cic/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cic/inventory/parser/cloud_manager.rb
@@ -1,2 +1,14 @@
 class ManageIQ::Providers::IbmCic::Inventory::Parser::CloudManager < ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager
+ 
+  def parse_vm(vm, hosts)
+    super
+    server = persister.vms.find_or_build(vm.id.to_s)
+    hardware = persister.hardwares.find_or_build(server)
+    # In openstack provider hardware cpu_speed is retrieved from the parent_host.
+    # hardware.cpu_speed = parent_host.try(:hardware).try(:cpu_speed)
+    # In cic provider, cpu_speed is from server details and set to hardware cpu_speed
+    if vm.attributes.key?("cpu_speed")
+      hardware.cpu_speed = vm.attributes["cpu_speed"]
+    end
+  end
 end


### PR DESCRIPTION
Override parse_vm to set cpu_speed to hardware. this cpu_speed is from cic server object by fog:openstack api call. 
 
