### PR TITLE
Add Service Catalog Provisioning support

### DIFF
--- a/app/models/manageiq/providers/ibm_cic/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cic/cloud_manager.rb
@@ -13,12 +13,14 @@ class ManageIQ::Providers::IbmCic::CloudManager < ManageIQ::Providers::Openstack
   require_nested :MetricsCollectorWorker
   require_nested :OrchestrationStack
   require_nested :PlacementGroup
+  require_nested :ProvisionWorkflow
   require_nested :Refresher
   require_nested :RefreshWorker
   require_nested :Snapshot
   require_nested :Template
   require_nested :Vm
 
+  supports :catalog
   supports :create
 
   def self.vm_vendor

--- a/app/models/manageiq/providers/ibm_cic/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cic/cloud_manager/provision_workflow.rb
@@ -1,0 +1,9 @@
+class ManageIQ::Providers::IbmCic::CloudManager::ProvisionWorkflow < ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow
+  def self.provider_model
+    ManageIQ::Providers::IbmCic::CloudManager
+  end
+
+  def dialog_name_from_automate(message = 'get_dialog_name')
+    super(message, {'platform' => 'ibm_cic'})
+  end
+end

--- a/content/miq_dialogs/miq_provision_ibm_cic_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_cic_dialogs_template.yaml
@@ -1,0 +1,427 @@
+---
+:name: miq_provision_ibm_cic_dialogs_template
+:description: Sample IBM CIC Instance Provisioning Dialog
+:dialog_type: MiqProvisionWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields:
+        :owner_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_country:
+          :description: Country/Region
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_phone_mobile:
+          :description: Mobile
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_title:
+          :description: Title
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_first_name:
+          :description: First Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager:
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_address:
+          :description: Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_company:
+          :description: Company
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_last_name:
+          :description: Last Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager_mail:
+          :description: E-Mail
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_city:
+          :description: City
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_department:
+          :description: Department
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_load_ldap:
+          :pressed:
+            :method: :retrieve_ldap
+          :description: Look Up LDAP Email
+          :required: false
+          :display: :show
+          :data_type: :button
+        :owner_manager_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_state:
+          :description: State
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_office:
+          :description: Office
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_zip:
+          :description: Zip code
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_email:
+          :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :request_notes:
+          :description: Notes
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+      :field_order:
+    :purpose:
+      :description: Purpose
+      :fields:
+        :vm_tags:
+          :required_method: :validate_tags
+          :description: Tags
+          :required: false
+          :options:
+            :include: []
+
+            :order: []
+
+            :single_select: []
+
+            :exclude: []
+
+          :display: :edit
+          :required_tags: []
+
+          :data_type: :integer
+      :display: :show
+      :field_order:
+    :environment:
+      :description: Environment
+      :fields:
+        :placement_auto:
+          :values:
+            false: 0
+            true: 1
+          :description: Choose Automatically
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :placement_availability_zone:
+          :values_from:
+            :method: :allowed_availability_zones
+          :auto_select_single: false
+          :description: Availability Zones
+          :required_method: :validate_placement
+          :required: false
+          :display: :edit
+          :data_type: :integer
+          :required_description: Availability Zone Name
+        :cloud_tenant:
+          :values_from:
+            :method: :allowed_cloud_tenants
+          :auto_select_single: false
+          :description: Cloud Tenant
+          :required_method: :validate_placement
+          :required: true
+          :display: :edit
+          :data_type: :integer
+        :cloud_network_selection_method:
+          :values:
+            network: Cloud Network
+            port: Network Port
+          :description: Network Selection Method
+          :required: false
+          :display: :edit
+          :default: network
+          :data_type: :string
+        :cloud_network:
+          :values_from:
+            :method: :allowed_cloud_networks
+          :description: Cloud Network
+          :auto_select_single: false
+          :required: true
+          :required_method: :validate_cloud_network
+          :display: :edit
+          :data_type: :integer
+        :network_port:
+          :values_from:
+            :method: :allowed_network_ports
+          :description: Network Port
+          :auto_select_single: false
+          :required: true
+          :required_method: :validate_network_port
+          :display: :edit
+          :data_type: :integer
+        :security_groups:
+          :values_from:
+            :method: :allowed_security_groups
+          :description: Security Groups
+          :required: false
+          :display: :edit
+          :data_type: :array_integer
+          :auto_select_single: false
+        :floating_ip_address:
+          :values_from:
+            :method: :allowed_floating_ip_addresses
+          :description: Public IP Address
+          :auto_select_single: false
+          :default: nil
+          :required: false
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :service:
+      :description: Catalog
+      :fields:
+        :number_of_vms:
+          :values_from:
+            :options:
+              :max: 50
+            :method: :allowed_number_of_vms
+          :description: Count
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :vm_description:
+          :description: Instance Description
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 100
+        :vm_prefix:
+          :description: Instance Name Prefix/Suffix
+          :required_method: :validate_vm_name
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :src_vm_id:
+          :values_from:
+            :options:
+              :tag_filters: []
+
+            :method: :allowed_templates
+          :description: Name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :vm_name:
+          :description: Instance Name
+          :required_method: :validate_vm_name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :string
+          :notes_display: :show
+          :min_length:
+          :max_length:
+      :display: :show
+    :schedule:
+      :description: Schedule
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+        :retirement:
+          :values:
+            0: Indefinite
+            1.month: 1 Month
+            3.months: 3 Months
+            6.months: 6 Months
+          :description: Time until Retirement
+          :required: false
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
+                1.week: 1 Week
+                2.weeks: 2 Weeks
+                30.days: 30 Days
+              :include_equals: false
+              :field: :retirement
+            :method: :values_less_then
+          :description: Retirement Warning
+          :required: true
+          :display: :edit
+          :default: 1.week
+          :data_type: :integer
+      :display: :show
+    :hardware:
+      :description: Properties
+      :fields:
+        :instance_type:
+          :values_from:
+            :method: :allowed_instance_types
+          :description: Instance Type
+          :required: true
+          :display: :edit
+          :data_type: :integer
+        :guest_access_key_pair:
+          :values_from:
+            :method: :allowed_guest_access_key_pairs
+          :description: Guest Access Key Pair
+          :auto_select_single: false
+          :default: nil
+          :required: false
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :volumes:
+      :description: Volumes
+      :fields:
+        :name:
+          :description: Volume Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 100
+        :size:
+          :description: Size (gigabytes)
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 10
+        :delete_on_terminate:
+          :description: Delete on Instance Terminate
+          :required: false
+          :display: :edit
+          :data_type: :boolean
+          :default: false
+      :display: :show
+    :customize:
+      :description: Customize
+      :fields:
+        :dns_servers:
+          :description: DNS Server list
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :dns_suffixes:
+          :description: DNS Suffix List
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :addr_mode:
+          :values:
+            static: Static
+            dhcp: DHCP
+          :description: Address Mode
+          :required: false
+          :display: :edit
+          :default: dhcp
+          :data_type: :string
+        :linux_host_name:
+          :description: Computer Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :gateway:
+          :description: Gateway
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :linux_domain_name:
+          :description: Domain Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :subnet_mask:
+          :description: Subnet Mask
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :customization_template_id:
+          :values_from:
+            :method: :allowed_customization_templates
+          :auto_select_single: false
+          :description: Script Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :customization_template_script:
+          :description: Script Text
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :root_password:
+          :description: Root Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :hostname:
+          :description: Host Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+  :dialog_order:
+  - :requester
+  - :purpose
+  - :service
+  - :environment
+  - :hardware
+  - :volumes
+  - :customize
+  - :schedule

--- a/spec/factories/availability_zone.rb
+++ b/spec/factories/availability_zone.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :availability_zone_ibm_cic,      :parent => :availability_zone_openstack, :class => "ManageIQ::Providers::IbmCic::CloudManager::AvailabilityZone"
+  factory :availability_zone_ibm_cic_null, :parent => :availability_zone_openstack_null, :class => "ManageIQ::Providers::IbmCic::CloudManager::AvailabilityZoneNull"
+end

--- a/spec/factories/cloud_network.rb
+++ b/spec/factories/cloud_network.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :cloud_network_ibm_cic,         :parent => :cloud_network_openstack, :class => "ManageIQ::Providers::IbmCic::NetworkManager::CloudNetwork"
+  factory :cloud_network_public_ibm_cic,  :parent => :cloud_network_public_openstack, :class => "ManageIQ::Providers::IbmCic::NetworkManager::CloudNetwork::Public"
+  factory :cloud_network_private_ibm_cic, :parent => :cloud_network_private_openstack, :class => "ManageIQ::Providers::IbmCic::NetworkManager::CloudNetwork::Private"
+end

--- a/spec/factories/cloud_subnet.rb
+++ b/spec/factories/cloud_subnet.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :cloud_subnet_ibm_cic, :parent => :cloud_subnet_openstack, :class => "ManageIQ::Providers::IbmCic::NetworkManager::CloudSubnet"
+end

--- a/spec/factories/cloud_tenant.rb
+++ b/spec/factories/cloud_tenant.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :cloud_tenant_ibm_cic, :parent => :cloud_subnet_openstack, :class => "ManageIQ::Providers::IbmCic::CloudManager::CloudTenant"
+end

--- a/spec/factories/flavor.rb
+++ b/spec/factories/flavor.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :flavor_ibm_cic, :parent => :flavor_openstack, :class => "ManageIQ::Providers::IbmCic::CloudManager::Flavor"
+end

--- a/spec/factories/network_router.rb
+++ b/spec/factories/network_router.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :network_router_ibm_cic, :parent => :network_router_openstack, :class => "ManageIQ::Providers::IbmCic::NetworkManager::NetworkRouter"
+end

--- a/spec/factories/security_group.rb
+++ b/spec/factories/security_group.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :security_group_ibm_cic, :parent => :security_group_openstack,
+                                   :class  => "ManageIQ::Providers::IbmCic::NetworkManager::SecurityGroup"
+end

--- a/spec/factories/vm_or_template.rb
+++ b/spec/factories/vm_or_template.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :template_ibm_cic, :class => "ManageIQ::Providers::IbmCic::CloudManager::Template", :parent => :template_openstack do
+    vendor { "ibm_z_vm" }
+  end
+end

--- a/spec/models/manageiq/providers/ibm_cic/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cic/cloud_manager/provision_workflow_spec.rb
@@ -1,10 +1,10 @@
 describe ManageIQ::Providers::IbmCic::CloudManager::ProvisionWorkflow do
   include Spec::Support::WorkflowHelper
 
-  let(:admin)    { FactoryBot.create(:user_with_group) }
+  let(:admin) { FactoryBot.create(:user_with_group) }
+  let(:zone)  { EvmSpecHelper.local_miq_server.zone }
   let(:provider) do
-    allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-    FactoryBot.create(:ems_ibm_cic)
+    FactoryBot.create(:ems_ibm_cic, :zone => zone)
   end
 
   let(:template) { FactoryBot.create(:template_ibm_cic, :ext_management_system => provider) }

--- a/spec/models/manageiq/providers/ibm_cic/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cic/cloud_manager/provision_workflow_spec.rb
@@ -1,0 +1,522 @@
+describe ManageIQ::Providers::IbmCic::CloudManager::ProvisionWorkflow do
+  include Spec::Support::WorkflowHelper
+
+  let(:admin)    { FactoryBot.create(:user_with_group) }
+  let(:provider) do
+    allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
+    FactoryBot.create(:ems_ibm_cic)
+  end
+
+  let(:template) { FactoryBot.create(:template_ibm_cic, :ext_management_system => provider) }
+
+  context "without applied tags" do
+    let(:workflow) do
+      stub_dialog
+      allow_any_instance_of(described_class).to receive(:update_field_visibility)
+      described_class.new({:src_vm_id => template.id}, admin.userid)
+    end
+    context "availability_zones" do
+      it "#get_targets_for_ems" do
+        az = FactoryBot.create(:availability_zone_ibm_cic)
+        provider.availability_zones << az
+        filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, AvailabilityZone,
+                                 'availability_zones.available')
+        expect(filtered.size).to eq(1)
+        expect(filtered.first.name).to eq(az.name)
+      end
+
+      it "returns an empty array when no targets are found" do
+        filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, AvailabilityZone,
+                                 'availability_zones.available')
+        expect(filtered).to eq([])
+      end
+    end
+
+    context "security_groups" do
+      context "non cloud network" do
+        it "#get_targets_for_ems" do
+          sg = FactoryBot.create(:security_group_ibm_cic, :ext_management_system => provider.network_manager)
+          filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, SecurityGroup,
+                                   'security_groups.non_cloud_network')
+          expect(filtered.size).to eq(1)
+          expect(filtered.first.name).to eq(sg.name)
+        end
+      end
+
+      context "cloud network" do
+        it "#get_targets_for_ems" do
+          cn1 = FactoryBot.create(:cloud_network, :ext_management_system => provider.network_manager)
+          sg_cn = FactoryBot.create(:security_group_ibm_cic, :ext_management_system => provider.network_manager, :cloud_network => cn1)
+          filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, SecurityGroup, 'security_groups')
+          expect(filtered.size).to eq(1)
+          expect(filtered.first.name).to eq(sg_cn.name)
+        end
+      end
+    end
+
+    context "Instance Type (Flavor)" do
+      it "#get_targets_for_ems" do
+        flavor = FactoryBot.create(:flavor_ibm_cic)
+        provider.flavors << flavor
+        filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, Flavor, 'flavors')
+        expect(filtered.size).to eq(1)
+        expect(filtered.first.name).to eq(flavor.name)
+      end
+    end
+  end
+
+  context "with applied tags" do
+    let(:workflow) do
+      stub_dialog
+      allow_any_instance_of(described_class).to receive(:update_field_visibility)
+      described_class.new({:src_vm_id => template.id}, admin.userid)
+    end
+
+    before do
+      FactoryBot.create(:classification_cost_center_with_tags)
+      admin.current_group.entitlement = Entitlement.create!
+      admin.current_group.entitlement.set_managed_filters([['/managed/cc/001']])
+      admin.current_group.save!
+
+      2.times { FactoryBot.create(:availability_zone_ibm_cic, :ems_id => provider.id) }
+      2.times { FactoryBot.create(:security_group_ibm_cic, :ext_management_system => provider.network_manager) }
+      ct1 = FactoryBot.create(:cloud_tenant)
+      ct2 = FactoryBot.create(:cloud_tenant)
+      provider.cloud_tenants << ct1
+      provider.cloud_tenants << ct2
+      provider.flavors << FactoryBot.create(:flavor_ibm_cic)
+      provider.flavors << FactoryBot.create(:flavor_ibm_cic)
+
+      tagged_zone = provider.availability_zones.first
+      tagged_sec = provider.security_groups.first
+      tagged_flavor = provider.flavors.first
+      tagged_tenant = provider.cloud_tenants.first
+      Classification.classify(tagged_zone, 'cc', '001')
+      Classification.classify(tagged_sec, 'cc', '001')
+      Classification.classify(tagged_flavor, 'cc', '001')
+      Classification.classify(tagged_tenant, 'cc', '001')
+    end
+
+    context "availability_zones" do
+      it "#get_targets_for_ems" do
+        expect(provider.availability_zones.size).to eq(2)
+        expect(provider.availability_zones.first.tags.size).to eq(1)
+        expect(provider.availability_zones.last.tags.size).to eq(0)
+
+        filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, AvailabilityZone,
+                                 'availability_zones.available')
+        expect(filtered.size).to eq(1)
+      end
+    end
+
+    context "security groups" do
+      it "#get_targets_for_ems" do
+        expect(provider.security_groups.size).to eq(2)
+        expect(provider.security_groups.first.tags.size).to eq(1)
+        expect(provider.security_groups.last.tags.size).to eq(0)
+
+        expect(workflow.send(:get_targets_for_ems,
+                             provider,
+                             :cloud_filter,
+                             SecurityGroup,
+                             'security_groups').size)
+          .to eq(1)
+      end
+    end
+
+    context "instance types (Flavor)" do
+      it "#get_targets_for_ems" do
+        expect(provider.flavors.size).to eq(2)
+        expect(provider.flavors.first.tags.size).to eq(1)
+        expect(provider.flavors.last.tags.size).to eq(0)
+
+        expect(workflow.send(:get_targets_for_ems, provider, :cloud_filter, Flavor, 'flavors').size).to eq(1)
+      end
+    end
+
+    context "allowed_tenants" do
+      it "#get_targets_for_ems" do
+        expect(provider.cloud_tenants.size).to eq(2)
+        expect(provider.cloud_tenants.first.tags.size).to eq(1)
+        expect(provider.cloud_tenants.last.tags.size).to eq(0)
+
+        expect(workflow.send(:get_targets_for_ems, provider, :cloud_filter, CloudTenant, 'cloud_tenants').size).to eq(1)
+      end
+    end
+  end
+
+  context "With a user" do
+    it "pass platform attributes to automate" do
+      stub_dialog
+      assert_automate_dialog_lookup(admin, 'cloud', 'ibm_cic')
+
+      described_class.new({}, admin.userid)
+    end
+
+    context "Without a Template" do
+      let(:workflow) do
+        stub_dialog
+        allow_any_instance_of(described_class).to receive(:update_field_visibility)
+        described_class.new({}, admin.userid)
+      end
+
+      it "#allowed_instance_types" do
+        provider.flavors << FactoryBot.create(:flavor_ibm_cic)
+
+        expect(workflow.allowed_instance_types).to eq({})
+      end
+    end
+
+    context "With a Valid Template" do
+      let(:workflow) do
+        stub_dialog
+        allow_any_instance_of(described_class).to receive(:update_field_visibility)
+        described_class.new({:src_vm_id => template.id}, admin.userid)
+      end
+
+      context "#allowed_instance_types" do
+        let(:template) { FactoryBot.create(:template_ibm_cic, :hardware => hardware, :ext_management_system => provider) }
+
+        context "with regular hardware" do
+          let(:hardware) { FactoryBot.create(:hardware, :size_on_disk => 1.gigabyte, :memory_mb_minimum => 512) }
+
+          it "filters flavors too small" do
+            flavor = FactoryBot.create(:flavor_ibm_cic, :memory => 1.gigabyte, :root_disk_size => 1.terabyte)
+            provider.flavors << flavor
+            provider.flavors << FactoryBot.create(:flavor_ibm_cic, :memory => 1.gigabyte, :root_disk_size => 1.megabyte) # Disk too small
+            provider.flavors << FactoryBot.create(:flavor_ibm_cic, :memory => 1.megabyte, :root_disk_size => 1.terabyte) # Memory too small
+
+            ram = ActionController::Base.helpers.number_to_human_size(flavor.memory)
+            disk_size = ActionController::Base.helpers.number_to_human_size(flavor.root_disk_size)
+            descr = "#{flavor.cpus} CPUs, #{ram} RAM, #{disk_size} Root Disk"
+
+            expect(workflow.allowed_instance_types).to eq(flavor.id => "#{flavor.name}: #{descr}")
+          end
+        end
+
+        context "hardware with no size_on_disk" do
+          let(:hardware) { FactoryBot.create(:hardware, :memory_mb_minimum => 512) }
+
+          it "filters flavors too small" do
+            flavor = FactoryBot.create(:flavor_ibm_cic, :memory => 1.gigabyte, :root_disk_size => 1.terabyte)
+            provider.flavors << flavor
+            provider.flavors << FactoryBot.create(:flavor_ibm_cic, :memory => 1.megabyte, :root_disk_size => 1.terabyte) # Memory too small
+
+            ram = ActionController::Base.helpers.number_to_human_size(flavor.memory)
+            disk_size = ActionController::Base.helpers.number_to_human_size(flavor.root_disk_size)
+            descr = "#{flavor.cpus} CPUs, #{ram} RAM, #{disk_size} Root Disk"
+
+            expect(workflow.allowed_instance_types).to eq(flavor.id => "#{flavor.name}: #{descr}")
+          end
+        end
+      end
+
+      context "with empty relationships" do
+        it "#allowed_availability_zones" do
+          expect(workflow.allowed_availability_zones).to eq({})
+        end
+
+        it "#allowed_guest_access_key_pairs" do
+          expect(workflow.allowed_guest_access_key_pairs).to eq({})
+        end
+
+        it "#allowed_security_groups" do
+          expect(workflow.allowed_security_groups).to eq({})
+        end
+      end
+
+      context "with valid relationships" do
+        it "#allowed_availability_zones" do
+          az = FactoryBot.create(:availability_zone_ibm_cic)
+          az.provider_services_supported = ["compute"]
+          excluded_az = FactoryBot.create(:availability_zone_ibm_cic)
+          excluded_az.provider_services_supported = ["volume"]
+          provider.availability_zones << az
+          expect(workflow.allowed_availability_zones).to eq(az.id => az.name)
+        end
+
+        it "#allowed_availability_zones with NULL AZ" do
+          az = FactoryBot.create(:availability_zone_ibm_cic)
+          az.provider_services_supported = ["compute"]
+          provider.availability_zones << az
+          provider.availability_zones << FactoryBot.create(:availability_zone_ibm_cic_null, :ems_ref => "null_az")
+
+          azs = workflow.allowed_availability_zones
+          expect(azs.length).to eq(1)
+          expect(azs.first).to eq([az.id, az.name])
+        end
+
+        it "#allowed_guest_access_key_pairs" do
+          kp = ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair.create(:name => "auth_1")
+          provider.key_pairs << kp
+          expect(workflow.allowed_guest_access_key_pairs).to eq(kp.id => kp.name)
+        end
+
+        it "#allowed_security_groups" do
+          sg = FactoryBot.create(:security_group_ibm_cic)
+          provider.security_groups << sg
+          expect(workflow.allowed_security_groups).to eq(sg.id => sg.name)
+        end
+      end
+
+      context "availability_zone_to_cloud_network" do
+        it "has one when it should" do
+          subnet = FactoryBot.create(:cloud_subnet_ibm_cic)
+          FactoryBot.create(:cloud_network_ibm_cic, :ext_management_system => provider.network_manager, :cloud_subnets => [subnet])
+
+          expect(workflow.allowed_cloud_networks.size).to eq(1)
+        end
+
+        it "filters cloud networks without subnets" do
+          FactoryBot.create(:cloud_network_ibm_cic, :ext_management_system => provider.network_manager)
+
+          expect(workflow.allowed_cloud_networks.size).to eq(0)
+        end
+
+        it "has none when it should" do
+          expect(workflow.allowed_cloud_networks.size).to eq(0)
+        end
+      end
+
+      context "#display_name_for_name_description" do
+        let(:flavor) { FactoryBot.create(:flavor_ibm_cic) }
+
+        it "with name and description" do
+          ram = ActionController::Base.helpers.number_to_human_size(flavor.memory)
+          disk_size = ActionController::Base.helpers.number_to_human_size(flavor.root_disk_size)
+          descr = "#{flavor.cpus} CPUs, #{ram} RAM, #{disk_size} Root Disk"
+          expect(workflow.display_name_for_name_description(flavor)).to eq("#{flavor.name}: #{descr}")
+        end
+      end
+
+      context "tenant filtering" do
+        before do
+          @ct1 = FactoryBot.create(:cloud_tenant_ibm_cic)
+          @ct2 = FactoryBot.create(:cloud_tenant_ibm_cic)
+          provider.cloud_tenants << @ct1
+          provider.cloud_tenants << @ct2
+        end
+
+        context "cloud networks" do
+          before do
+            subnet1 = FactoryBot.create(:cloud_subnet_ibm_cic)
+            subnet2 = FactoryBot.create(:cloud_subnet_ibm_cic)
+            subnet3 = FactoryBot.create(:cloud_subnet_ibm_cic)
+            subnet4 = FactoryBot.create(:cloud_subnet_ibm_cic)
+            subnet5 = FactoryBot.create(:cloud_subnet_ibm_cic)
+            @cn1 = FactoryBot.create(:cloud_network_private_ibm_cic,
+                                     :cloud_tenant          => @ct1,
+                                     :ext_management_system => provider.network_manager,
+                                     :cloud_subnets         => [subnet1])
+            @cn2 = FactoryBot.create(:cloud_network_private_ibm_cic,
+                                     :cloud_tenant          => @ct2,
+                                     :ext_management_system => provider.network_manager,
+                                     :cloud_subnets         => [subnet2])
+            @cn3 = FactoryBot.create(:cloud_network_public_ibm_cic,
+                                     :cloud_tenant          => @ct2,
+                                     :ext_management_system => provider.network_manager,
+                                     :cloud_subnets         => [subnet3])
+
+            @cn_shared        = FactoryBot.create(:cloud_network_private_ibm_cic,
+                                                  :shared                => true,
+                                                  :cloud_tenant          => @ct2,
+                                                  :ext_management_system => provider.network_manager,
+                                                  :cloud_subnets         => [subnet4])
+            @cn_public_shared = FactoryBot.create(:cloud_network_public_ibm_cic,
+                                                  :shared                => true,
+                                                  :cloud_tenant          => @ct2,
+                                                  :ext_management_system => provider.network_manager,
+                                                  :cloud_subnets         => [subnet5])
+          end
+
+          it "#allowed_cloud_networks with tenant selected" do
+            workflow.values[:cloud_tenant] = @ct2.id
+            cns = workflow.allowed_cloud_networks
+            expect(cns.keys).to match_array [@cn2.id, @cn3.id, @cn_shared.id, @cn_public_shared.id]
+          end
+
+          it "#allowed_cloud_networks with another tenant selected" do
+            workflow.values[:cloud_tenant] = @ct1.id
+            cns = workflow.allowed_cloud_networks
+            expect(cns.keys).to match_array [@cn1.id, @cn_shared.id, @cn_public_shared.id]
+          end
+
+          it "#allowed_cloud_networks with tenant not selected" do
+            cns = workflow.allowed_cloud_networks
+            expect(cns.keys).to match_array [@cn2.id, @cn3.id, @cn1.id, @cn_shared.id, @cn_public_shared.id]
+          end
+        end
+
+        context "security groups" do
+          before do
+            @sg1 = FactoryBot.create(:security_group_ibm_cic)
+            @sg2 = FactoryBot.create(:security_group_ibm_cic)
+            provider.network_manager.security_groups << @sg1
+            provider.network_manager.security_groups << @sg2
+            @ct1.security_groups << @sg1
+            @ct2.security_groups << @sg2
+          end
+
+          it "#allowed_security_groups with tenant selected" do
+            workflow.values[:cloud_tenant] = @ct2.id
+            sgs = workflow.allowed_security_groups
+            expect(sgs.keys).to match_array [@sg2.id]
+          end
+
+          it "#allowed_security_groups with tenant not selected" do
+            sgs = workflow.allowed_security_groups
+            expect(sgs.keys).to match_array [@sg2.id, @sg1.id]
+          end
+        end
+
+        context "floating ip" do
+          before do
+            cloud_network_public   = FactoryBot.create(:cloud_network_public_ibm_cic)
+            cloud_network_public_2 = FactoryBot.create(:cloud_network_public_ibm_cic)
+            router                 = FactoryBot.create(:network_router_ibm_cic,
+                                                       :cloud_network => cloud_network_public)
+            @cloud_network         = FactoryBot.create(:cloud_network_private_ibm_cic,
+                                                       :cloud_tenant => @ct2)
+            @cloud_network_2       = FactoryBot.create(:cloud_network_private_ibm_cic,
+                                                       :cloud_tenant => @ct2)
+            _subnet                = FactoryBot.create(:cloud_subnet_ibm_cic,
+                                                       :network_router        => router,
+                                                       :cloud_network         => @cloud_network,
+                                                       :ext_management_system => provider.network_manager)
+
+            @ip1 = FactoryBot.create(:floating_ip,
+                                     :address       => "1.1.1.1",
+                                     :cloud_tenant  => @ct1,
+                                     :cloud_network => cloud_network_public)
+            @ip2 = FactoryBot.create(:floating_ip,
+                                     :address       => "2.2.2.2",
+                                     :cloud_tenant  => @ct2,
+                                     :cloud_network => cloud_network_public)
+            @ip3 = FactoryBot.create(:floating_ip,
+                                     :address       => "2.2.2.3",
+                                     :cloud_tenant  => @ct2,
+                                     :cloud_network => cloud_network_public_2)
+          end
+
+          it "#allowed_floating_ip_addresses with tenant selected" do
+            workflow.values[:cloud_tenant]  = @ct2.id
+            workflow.values[:cloud_network] = @cloud_network.id
+            ips = workflow.allowed_floating_ip_addresses
+            expect(ips.keys).to match_array [@ip2.id]
+          end
+
+          it "#allowed_floating_ip_addresses with tenant not selected" do
+            workflow.values[:cloud_network] = @cloud_network.id
+            ips = workflow.allowed_floating_ip_addresses
+            expect(ips.keys).to match_array [@ip2.id, @ip1.id]
+          end
+
+          it "#allowed_floating_ip_addresses with network not connected to the router" do
+            workflow.values[:cloud_network] = @cloud_network_2.id
+            ips = workflow.allowed_floating_ip_addresses
+            expect(ips.keys).to match_array []
+          end
+        end
+      end
+    end
+  end
+
+  describe "prepare_volumes_fields" do
+    let(:workflow) do
+      stub_dialog
+      allow_any_instance_of(described_class).to receive(:update_field_visibility)
+      described_class.new({:src_vm_id => template.id}, admin.userid)
+    end
+
+    context "converts numbered volume form fields into an array" do
+      it "with no default values" do
+        volumes = workflow.prepare_volumes_fields(
+          :name_1 => "v1n", :size_1 => "v1s", :delete_on_terminate_1 => true,
+          :name_2 => "v2n", :size_2 => "v2s", :delete_on_terminate_2 => false,
+          :other_irrelevant_key => 1
+        )
+        expect(volumes.length).to eq(2)
+        expect(volumes[0]).to eq(:name => "v1n", :size => "v1s", :delete_on_terminate => true)
+        expect(volumes[1]).to eq(:name => "v2n", :size => "v2s", :delete_on_terminate => false)
+      end
+      it "with default size" do
+        volumes = workflow.prepare_volumes_fields(
+          :name_1 => "v1n", :size_1 => "v1s", :delete_on_terminate_1 => true,
+          :name_2 => "v2n", :size_2 => "", :delete_on_terminate_2 => false,
+          :name_3 => "v3n", :delete_on_terminate_3 => false,
+          :other_irrelevant_key => 1
+        )
+        expect(volumes.length).to eq(3)
+        expect(volumes[0]).to eq(:name => "v1n", :size => "v1s", :delete_on_terminate => true)
+        expect(volumes[1]).to eq(:name => "v2n", :size => "1", :delete_on_terminate => false)
+        expect(volumes[2]).to eq(:name => "v3n", :size => "1", :delete_on_terminate => false)
+      end
+      it "with empty name if only size given" do
+        volumes = workflow.prepare_volumes_fields(
+          :name_1 => "v1n", :size_1 => "v1s", :delete_on_terminate_1 => true,
+          :size_2 => "v2s", :delete_on_terminate_2 => false,
+          :other_irrelevant_key => 1
+        )
+        expect(volumes.length).to eq(2)
+        expect(volumes[0]).to eq(:name => "v1n", :size => "v1s", :delete_on_terminate => true)
+        expect(volumes[1]).to eq(:name => "", :size => "v2s", :delete_on_terminate => false)
+      end
+    end
+
+    it "produces an empty array if there are no volume fields" do
+      volumes = workflow.prepare_volumes_fields(:other_irrelevant_key => 1)
+      expect(volumes.length).to eq(0)
+    end
+  end
+
+  describe "#make_request" do
+    let(:alt_user) { FactoryBot.create(:user_with_group) }
+
+    it "creates and update a request" do
+      EvmSpecHelper.local_miq_server
+      stub_dialog(:get_pre_dialogs)
+      stub_dialog(:get_dialogs)
+
+      # if running_pre_dialog is set, it will run 'continue_request'
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_provision_request_created",
+        :target_class => "Vm",
+        :userid       => admin.userid,
+        :message      => "VM Provisioning requested by <#{admin.userid}> for Vm:#{template.id}"
+      )
+
+      # creates a request
+      stub_get_next_vm_name
+
+      # the dialogs populate this
+      values[:src_vm_id] = template.id
+      values[:vm_tags] = []
+
+      request = workflow.make_request(nil, values)
+
+      expect(request).to be_valid
+      expect(request).to be_a_kind_of(MiqProvisionRequest)
+      expect(request.request_type).to eq("template")
+      expect(request.description).to eq("Provision from [#{template.name}] to [New VM]")
+      expect(request.requester).to eq(admin)
+      expect(request.userid).to eq(admin.userid)
+      expect(request.requester_name).to eq(admin.name)
+
+      # updates a request
+
+      stub_get_next_vm_name
+
+      workflow = described_class.new(values, alt_user)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_provision_request_updated",
+        :target_class => "Vm",
+        :userid       => alt_user.userid,
+        :message      => "VM Provisioning request updated by <#{alt_user.userid}> for Vm:#{template.id}"
+      )
+      workflow.make_request(request, values)
+    end
+  end
+end


### PR DESCRIPTION
Add a ProvisionWorkflow subclass and `supports :catalog` to allow IBM CIC providers to provision VMs via Service Catalog

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/840

Fixes https://github.com/ManageIQ/manageiq-providers-ibm_cic/issues/28