### PR TITLE
add IBM CIC missing catalog type

### DIFF
--- a/app/models/manageiq/providers/ibm_cic/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cic/cloud_manager.rb
@@ -13,6 +13,7 @@ class ManageIQ::Providers::IbmCic::CloudManager < ManageIQ::Providers::Openstack
   require_nested :MetricsCollectorWorker
   require_nested :OrchestrationStack
   require_nested :PlacementGroup
+  require_nested :Provision
   require_nested :ProvisionWorkflow
   require_nested :Refresher
   require_nested :RefreshWorker

--- a/app/models/manageiq/providers/ibm_cic/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cic/cloud_manager.rb
@@ -35,6 +35,10 @@ class ManageIQ::Providers::IbmCic::CloudManager < ManageIQ::Providers::Openstack
     @description ||= "IBM Cloud Infrastructure Center".freeze
   end
 
+  def self.catalog_types
+    {"IbmCic" => N_("IBM Cloud Infrastructure Center")}
+  end
+
   has_one :network_manager,
           :foreign_key => :parent_ems_id,
           :class_name  => "ManageIQ::Providers::IbmCic::NetworkManager",

--- a/app/models/manageiq/providers/ibm_cic/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/ibm_cic/cloud_manager/provision.rb
@@ -1,0 +1,4 @@
+ManageIQ::Providers::Openstack::CloudManager::Provision.include(ActsAsStiLeafClass)
+
+class ManageIQ::Providers::IbmCic::CloudManager::Provision < ManageIQ::Providers::Openstack::CloudManager::Provision
+end


### PR DESCRIPTION
- the catalog type was missing which meant a IBM CIC catalog item was not selectable from the UI
- workflow provisioning is being inherited from the openstack provider

@miq-bot assign @agrare 