### PR TITLE
Delegate refresh_ems class method to parent cloud manager

### DIFF
--- a/app/models/manageiq/providers/ibm_cic/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cic/network_manager.rb
@@ -1,6 +1,10 @@
 ManageIQ::Providers::Openstack::NetworkManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmCic::NetworkManager < ManageIQ::Providers::Openstack::NetworkManager
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::IbmCic::CloudManager
+  end
+
   def self.ems_type
     @ems_type ||= "ibm_cic_network".freeze
   end

--- a/app/models/manageiq/providers/ibm_cic/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/ibm_cic/storage_manager/cinder_manager.rb
@@ -1,6 +1,10 @@
 ManageIQ::Providers::Openstack::StorageManager::CinderManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmCic::StorageManager::CinderManager < ManageIQ::Providers::Openstack::StorageManager::CinderManager
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::IbmCic::CloudManager
+  end
+
   def self.ems_type
     @ems_type ||= "ibm_cic_cinder".freeze
   end

--- a/app/models/manageiq/providers/ibm_cic/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/ibm_cic/storage_manager/swift_manager.rb
@@ -1,6 +1,10 @@
 ManageIQ::Providers::Openstack::StorageManager::SwiftManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmCic::StorageManager::SwiftManager < ManageIQ::Providers::Openstack::StorageManager::SwiftManager
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::IbmCic::CloudManager
+  end
+
   def self.ems_type
     @ems_type ||= "ibm_cic_swift".freeze
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,10 +7,14 @@
     :parallel_thread_limit: 0
   :ibm_cic_network:
     :is_admin: false
+    :refresh_interval: 0
   :ibm_cic_infra:
     :is_admin: false
-  :cinder:
+  :ibm_cic_cinder:
     :is_admin: false
+    :refresh_interval: 0
+  :ibm_cic_swift:
+    :refresh_interval: 0
 :ems:
   :ems_ibm_cic:
     :excon:


### PR DESCRIPTION
Reasoning here: https://github.com/ManageIQ/manageiq-providers-azure/pull/564#issuecomment-2445034651

@miq-bot assign @agrare
@miq-bot add_label bug, radjabov/yes?
@miq-bot add_reviewer @agrare